### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/svg-png-labels.md
+++ b/.changeset/svg-png-labels.md
@@ -1,5 +1,0 @@
----
-'sldeditor': patch
----
-
-Include element labels and free text annotations in SVG/PNG exports — previously only DXF carried them, leaving the raster/vector outputs missing the IDs, showOnCanvas params, and any notes the user dropped via the text tool. `downloadSvg` / `downloadPng` now honor `labelMode` and accept an `annotations` array (defaults wired through `ExportMenu`). Label/annotation positioning matches the canvas exactly because all three surfaces — `AnnotationLayer`, DXF, SVG — now share a single helper module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# sldeditor
+
+## 0.0.2
+
+### Patch Changes
+
+- [`cf59604`](https://github.com/NovaShang/sldeditor/commit/cf596043472caec8572b5491ac199992809d9ad2) Thanks [@NovaShang](https://github.com/NovaShang)! - Include element labels and free text annotations in SVG/PNG exports — previously only DXF carried them, leaving the raster/vector outputs missing the IDs, showOnCanvas params, and any notes the user dropped via the text tool. `downloadSvg` / `downloadPng` now honor `labelMode` and accept an `annotations` array (defaults wired through `ExportMenu`). Label/annotation positioning matches the canvas exactly because all three surfaces — `AnnotationLayer`, DXF, SVG — now share a single helper module.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sldeditor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Lightweight in-browser React editor for electrical single-line diagrams (SLD).",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Auto-generated by [Changesets](https://github.com/changesets/changesets) — merging this PR bumps the version and publishes to npm via the Release workflow.

## Releases

### sldeditor@0.0.2

**Patch**: Include element labels and free text annotations in SVG/PNG exports — previously only DXF carried them, leaving the raster/vector outputs missing the IDs, showOnCanvas params, and any notes the user dropped via the text tool. ``downloadSvg`` / ``downloadPng`` now honor ``labelMode`` and accept an ``annotations`` array (defaults wired through ``ExportMenu``). Label/annotation positioning matches the canvas exactly because all three surfaces — ``AnnotationLayer``, DXF, SVG — now share a single helper module.